### PR TITLE
fix potential null pointer dereference

### DIFF
--- a/src/libs/zbxdbmon/dbmon.c
+++ b/src/libs/zbxdbmon/dbmon.c
@@ -327,10 +327,12 @@ int zbx_db_clean_fields(struct zbx_db_fields *e_data)
 {
 	if (NULL != e_data)
 	{
-		zbx_db_free(((struct zbx_db_type_text *)e_data->t_data)->value);
-
 		if (NULL != e_data->t_data)
 		{
+			if (NULL != ((struct zbx_db_type_text *)e_data->t_data)->value)
+			{
+				zbx_db_free(((struct zbx_db_type_text *)e_data->t_data)->value);
+			}
 			zbx_db_free(e_data->t_data);
 		}
 


### PR DESCRIPTION
found by coverity

```
     	deref_ptr: Directly dereferencing pointer e_data->t_data.
330                zbx_db_free(((struct zbx_db_type_text *)e_data->t_data)->value);
331

CID 455933: (#1 of 1): Dereference before null check (REVERSE_INULL) check_after_deref: Null-checking e_data->t_data suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
332                if (NULL != e_data->t_data)
333                {
334                        zbx_db_free(e_data->t_data);
335                }
```